### PR TITLE
Add arguments and switches to visualization.py

### DIFF
--- a/scenario.py
+++ b/scenario.py
@@ -17,15 +17,21 @@ class Scenario:
     - simulator
     - robot
     """
+
     def __init__(self, scenario_id, robot_pose=None, with_platform=True):
         # load scene
         self.id = scenario_id
-        self.scene_fn = os.path.join(util.SCENARIO_DIR, f'{scenario_id:03d}', 'scene.yaml')
+        scenario_dir = os.path.join(
+            os.path.dirname(__file__), util.SCENARIO_DIR)
+        self.scene_fn = os.path.join(
+            scenario_dir, f'{scenario_id:03d}', 'scene.yaml')
         self.scene, lib, _ = burg.Scene.from_yaml(self.scene_fn)
-        print(f'loaded scene with {len(self.scene.objects)} objects and {len(self.scene.bg_objects)} obstacles.')
+        print(
+            f'loaded scene with {len(self.scene.objects)} objects and {len(self.scene.bg_objects)} obstacles.')
 
         # fetch corresponding grasps
-        grasps_fn = os.path.join(util.SCENARIO_DIR, f'{scenario_id:03d}', 'grasps.npy')
+        grasps_fn = os.path.join(
+            scenario_dir, f'{scenario_id:03d}', 'grasps.npy')
         grasps = np.load(grasps_fn, allow_pickle=True)
         # convert from BURG to franka frame
         grasps = grasps @ FrankaRobot.tf_grasp2ee
@@ -51,7 +57,8 @@ class Scenario:
             return
 
         if n > len(self.gs):
-            raise ValueError('cannot select more grasps than available. n must be smaller than number of grasps')
+            raise ValueError(
+                'cannot select more grasps than available. n must be smaller than number of grasps')
 
         rng = np.random.default_rng(seed)
         self.select_indices = rng.choice(len(self.gs), n, replace=False)
@@ -62,7 +69,8 @@ class Scenario:
         """
         sim = GraspingSimulator(verbose=with_gui)
         sim.add_scene(self.scene)
-        robot = FrankaRobot(sim, self.robot_pose, with_platform=self.with_platform)
+        robot = FrankaRobot(sim, self.robot_pose,
+                            with_platform=self.with_platform)
 
         return robot, sim
 
@@ -96,10 +104,12 @@ class Scenario:
         for g in range(len(self.gs)):
             count.start('calculate IK')
             target_pose = self.gs.poses[g]
-            pos, orn = burg.util.position_and_quaternion_from_tf(target_pose, convention='pybullet')
+            pos, orn = burg.util.position_and_quaternion_from_tf(
+                target_pose, convention='pybullet')
 
             # do the actual IK
-            target_conf = robot.inverse_kinematics(pos, orn, null_space_control=True)
+            target_conf = robot.inverse_kinematics(
+                pos, orn, null_space_control=True)
             count.stop('calculate IK')
             count.start('perform checks')
             if target_conf is not None:

--- a/visualization.py
+++ b/visualization.py
@@ -1,4 +1,9 @@
+import re
+from typing import *
+import csv
+import argparse
 import os
+import sys
 import time
 
 import numpy as np
@@ -18,7 +23,8 @@ class ImageRenderer:
         # pybullet stuff
         self.bullet_client = bullet_client
         if camera_pose is None:
-            camera_pose = burg.util.look_at(position=[2.7, -1.5, 1.5], target=[1, 0.3, 0.1], flip=True)
+            camera_pose = burg.util.look_at(
+                position=[2.7, -1.5, 1.5], target=[1, 0.3, 0.1], flip=True)
         self.camera_pose = camera_pose
 
         # compute projection matrix from kinect-like camera parameters
@@ -29,7 +35,8 @@ class ImageRenderer:
         self._projection_matrix = np.array([
             [2 * fx / self.w, 0, 0, 0],
             [0, 2 * fy / self.h, 0, 0],
-            [-(2 * cx / self.w - 1), 2 * cy / self.h - 1, (self.znear + self.zfar) / (self.znear - self.zfar), -1],
+            [-(2 * cx / self.w - 1), 2 * cy / self.h - 1,
+             (self.znear + self.zfar) / (self.znear - self.zfar), -1],
             [0, 0, (2 * self.znear * self.zfar) / (self.znear - self.zfar), 0]
         ])
         self._ambient_light = [1., 1., 1.]
@@ -64,27 +71,44 @@ class FourImageRenderer:
     def __init__(self, scenario):
         cam_poses = []
         if scenario.id == 1:
-            cam1 = burg.util.look_at(position=[2.7, -1.5, 1.5], target=[1, 0.3, 0.1], flip=True)
-            cam2 = burg.util.look_at(position=[2.1, 1.5, 1.5], target=[1, 0.3, 0.1], flip=True)
-            cam3 = burg.util.look_at(position=[1.5, 0.75, 0.2], target=[1, 0.7, 0.1], flip=True)
-            cam4 = burg.util.look_at(position=[1.0, 1.3, 0.2], target=[1, 0.7, 0.1], flip=True)
+            cam1 = burg.util.look_at(
+                position=[2.7, -1.5, 1.5], target=[1, 0.3, 0.1], flip=True)
+            cam2 = burg.util.look_at(position=[2.1, 1.5, 1.5], target=[
+                                     1, 0.3, 0.1], flip=True)
+            cam3 = burg.util.look_at(position=[1.5, 0.75, 0.2], target=[
+                                     1, 0.7, 0.1], flip=True)
+            cam4 = burg.util.look_at(position=[1.0, 1.3, 0.2], target=[
+                                     1, 0.7, 0.1], flip=True)
         elif scenario.id == 2:
-            cam1 = burg.util.look_at(position=[2.7, -1.5, 1.5], target=[1, 0.3, 0.1], flip=True)
-            cam2 = burg.util.look_at(position=[-0.2, -1.1, 1.5], target=[1, 0.3, 0.1], flip=True)
-            cam3 = burg.util.look_at(position=[1.15, 0.5, 0.8], target=[1, 0.7, 0.5], flip=True)
-            cam4 = burg.util.look_at(position=[0.9, 1.4, 0.8], target=[1, 0.7, 0.5], flip=True)
+            cam1 = burg.util.look_at(
+                position=[2.7, -1.5, 1.5], target=[1, 0.3, 0.1], flip=True)
+            cam2 = burg.util.look_at(
+                position=[-0.2, -1.1, 1.5], target=[1, 0.3, 0.1], flip=True)
+            cam3 = burg.util.look_at(position=[1.15, 0.5, 0.8], target=[
+                                     1, 0.7, 0.5], flip=True)
+            cam4 = burg.util.look_at(position=[0.9, 1.4, 0.8], target=[
+                                     1, 0.7, 0.5], flip=True)
         elif scenario.id == 3:
-            cam1 = burg.util.look_at(position=[2.7, -1.5, 1.5], target=[1, 0.3, 0.1], flip=True)
-            cam2 = burg.util.look_at(position=[-0.7, -1.5, 1.5], target=[1, 0.3, 0.1], flip=True)
-            cam3 = burg.util.look_at(position=[1.7, 0.5, 0.3], target=[1, 0.8, 0.1], flip=True)
-            cam4 = burg.util.look_at(position=[0.4, 1.1, 0.2], target=[1, 0.75, 0.1], flip=True)
+            cam1 = burg.util.look_at(
+                position=[2.7, -1.5, 1.5], target=[1, 0.3, 0.1], flip=True)
+            cam2 = burg.util.look_at(
+                position=[-0.7, -1.5, 1.5], target=[1, 0.3, 0.1], flip=True)
+            cam3 = burg.util.look_at(position=[1.7, 0.5, 0.3], target=[
+                                     1, 0.8, 0.1], flip=True)
+            cam4 = burg.util.look_at(position=[0.4, 1.1, 0.2], target=[
+                                     1, 0.75, 0.1], flip=True)
         else:
-            cam1 = burg.util.look_at(position=[2.7, -1.5, 1.5], target=[1, 0.3, 0.1], flip=True)
-            cam2 = burg.util.look_at(position=[1.8, 2.0, 1.2], target=[1, 0.3, 0.1], flip=True)
-            cam3 = burg.util.look_at(position=[0.2, 2.0, 0.8], target=[1, 0.7, 0.5], flip=True)
-            cam4 = burg.util.look_at(position=[1.2, 1.8, 0.8], target=[1, 0.7, 0.5], flip=True)
+            cam1 = burg.util.look_at(
+                position=[2.7, -1.5, 1.5], target=[1, 0.3, 0.1], flip=True)
+            cam2 = burg.util.look_at(position=[1.8, 2.0, 1.2], target=[
+                                     1, 0.3, 0.1], flip=True)
+            cam3 = burg.util.look_at(position=[0.2, 2.0, 0.8], target=[
+                                     1, 0.7, 0.5], flip=True)
+            cam4 = burg.util.look_at(position=[1.2, 1.8, 0.8], target=[
+                                     1, 0.7, 0.5], flip=True)
 
-        self.renderers = [ImageRenderer(camera_pose=c) for c in [cam1, cam2, cam3, cam4]]
+        self.renderers = [ImageRenderer(camera_pose=c)
+                          for c in [cam1, cam2, cam3, cam4]]
         self.w = self.renderers[0].w * 2
         self.h = self.renderers[0].h * 2
 
@@ -156,15 +180,17 @@ def visualize_waypoints(scenario, list_of_waypoints, target_pose=None, step_time
         pos, orn = robot.forward_kinematics(list_of_waypoints[i])
 #        fkin_frame_ids.append(sim.add_frame(pos=pos, orn=orn))
         if i > 0:
-            d = sum([ (prevPos[i] - pos[i])**2 for i in range(3) ])**(1/2) #distance between two consecutive waypoints
+            # distance between two consecutive waypoints
+            d = sum([(prevPos[i] - pos[i])**2 for i in range(3)])**(1/2)
             steps = int(d / 0.01) + 1
-            interpolation = [ prevPos*(1-i/steps) + (pos*i/steps) for i in range(steps) ]
+            interpolation = [prevPos*(1-i/steps) + (pos*i/steps)
+                             for i in range(steps)]
             print(interpolation)
             for ipos in interpolation:
-                fkin_frame_ids.append(sim.add_sphere(pos=ipos, orn=orn, scale=0.01))
-            
-        prevPos = pos
+                fkin_frame_ids.append(sim.add_sphere(
+                    pos=ipos, orn=orn, scale=0.01))
 
+        prevPos = pos
 
     while first_run or repeat:
         i = 0
@@ -179,7 +205,8 @@ def visualize_waypoints(scenario, list_of_waypoints, target_pose=None, step_time
             if step_time is None or step_time <= 0:
                 # manual mode
                 print('current waypoint:', list_of_waypoints[i])
-                key = input(f'{i+1}/{len(list_of_waypoints)}: enter to proceed, p for previous, q to quit')
+                key = input(
+                    f'{i+1}/{len(list_of_waypoints)}: enter to proceed, p for previous, q to quit')
                 if key == 'q':
                     repeat = False
                     break
@@ -206,11 +233,13 @@ def create_video(scenario, waypoints, video_fn, renderer, target_pose=None, fps=
     if target_pose is not None:
         sim.add_frame(tf=target_pose)
 
-    video_writer = cv2.VideoWriter(f'{video_fn}.mp4', cv2.VideoWriter_fourcc(*'mp4v'), fps, (renderer.w, renderer.h))
+    video_writer = cv2.VideoWriter(f'{video_fn}.mp4', cv2.VideoWriter_fourcc(
+        *'mp4v'), fps, (renderer.w, renderer.h))
 
     for i in range(len(waypoints)):
         # robot.reset_arm_joints(list_of_waypoints[i])
-        pos, orn = robot.forward_kinematics(waypoints[i])  # automatically resets arm
+        pos, orn = robot.forward_kinematics(
+            waypoints[i])  # automatically resets arm
         fkin_frame_id = sim.add_frame(pos=pos, orn=orn)
 
         # make picture
@@ -233,63 +262,108 @@ def show_scenario(scenario):
     visualize_waypoints(scenario, list_of_waypoints, step_time=0, repeat=False)
 
 
-def test_vis(scenario, trajFile):
-    waypoints = [
-        [ 0.        ,  0.        , -0.01779206, -0.76012354,  0.01978261, -2.34205014,  0.02984053,  1.54119353,  0.75344866],
-        [ 0.04      ,  0.04      ,  0.07543812, -0.72490447,  0.07638708, -2.37448407,  0.06908042,  1.54488921,  0.67831372],
-        [ 0.08      ,  0.08      ,  0.1657339 , -0.6865332 ,  0.12951995, -2.40180711,  0.10798703,  1.55301725,  0.60104267],
-        [ 0.03348037, -0.13874396,  0.2844179 , -0.6132292 ,  0.24820395, -2.33897511,  0.22667103,  1.63120925, -1.23003653],
-        [ 0.03348037, -0.13874396,  0.4031019 , -0.5399252 ,  0.36688795, -2.27614311,  0.34535503,  1.70940125, -1.23003653],
-        [ 0.03348037, -0.13874396,  0.51508008, -0.4666212 ,  0.48557195, -2.24875362,  0.46403903,  1.78759325, -1.23003653],
-        [ 0.03348037, -0.13874396,  0.51508008, -0.3933172 ,  0.60425595, -2.24875362,  0.58272303,  1.86578525, -1.23003653],
-        [ 0.03348037, -0.13874396,  0.51508008, -0.3200132 ,  0.72293995, -2.24875362,  0.70140703,  1.94397725, -1.23003653],
-        [ 0.07348037, -0.22830728,  0.63376408, -0.2467092 ,  0.84162395, -2.18592162,  0.82009103,  2.02216925, -1.11135253],
-        [ 0.11348037, -0.22830728,  0.74118352, -0.1734052 ,  0.96030795, -2.12308962,  0.93877503,  2.10036125, -0.99266853],
-        [ 0.15348037, -0.22830728,  0.74118352, -0.1001012 ,  1.07899195, -2.06025762,  1.05745903,  2.17855325, -0.87398453],
-        [ 0.19348037, -0.22830728,  0.74118352, -0.0267972 ,  1.19767595, -1.99742562,  1.17614303,  2.25674525, -0.75530053],
-        [ 0.21450446, -0.18830728,  0.18224764, -1.16490337,  1.31635995, -1.93459362,  1.12311681,  2.33493725, -1.06778578],
-        [ 0.21450446, -0.14830728,  0.18224764, -1.16490337,  1.43504395, -1.87176162,  1.12311681,  2.36596726, -1.06778578],
-        [ 0.21450446, -0.10830728,  0.18224764, -1.16490337,  1.55372795, -1.80892962,  1.12311681,  2.36596726, -1.06778578],
-        [ 0.21450446, -0.06830728,  0.18224764, -1.16490337,  1.67241195, -1.74609762,  1.12311681,  2.36596726, -1.06778578],
-        [ 0.21450446, -0.02830728,  0.18224764, -1.16490337,  1.79109595, -1.68326562,  1.12311681,  2.36596726, -1.06778578],
-        [ 0.25450446, -0.1576753 ,  0.30093164, -1.35041388,  1.50455529, -1.62043362,  0.50948168,  2.44415926, -0.94910178],
-        [ 0.29450446, -0.1576753 ,  0.41961564, -1.35041388,  1.50455529, -1.55760162,  0.50948168,  2.52235126, -0.83041778],
-        [ 0.33450446, -0.1576753 ,  0.53829964, -1.35041388,  1.50455529, -1.49476962,  0.50948168,  2.60054326, -0.71173378],
-        [ 0.37450446, -0.1576753 ,  0.65698364, -1.35041388,  1.50455529, -1.43193762,  0.50948168,  2.67873526, -0.59304978],
-        [ 0.41450446, -0.1576753 ,  0.77566764, -1.35041388,  1.50455529, -1.36910562,  0.50948168,  2.75692726, -0.47436578],
-        [ 0.45450446, -0.1176753 ,  0.46978508, -1.27710988,  1.62323929, -1.30627362,  0.62816568,  2.56588813, -0.35568178],
-        [ 0.49450446, -0.0776753 ,  0.46978508, -1.20380588,  1.74192329, -1.26018591,  0.74684968,  2.56588813, -0.23699778],
-        [ 0.53450446, -0.31055444,  0.58846908, -1.13050188,  1.86060729, -1.19735391, -0.01269374,  1.9406962 , -0.27375675],
-        [ 0.57450446, -0.3453008 , -1.4687618 , -1.05719788,  1.86690121, -1.37613417, -0.45294696,  2.0188882 , -0.18192514],
-        [ 0.61450446, -0.3453008 , -1.4687618 , -0.98389388,  1.86690121, -1.37613417, -0.45294696,  2.0970802 , -0.18192514],
-        [ 0.65450446, -0.3453008 , -1.4687618 , -0.91058988,  1.86690121, -1.37613417, -0.45294696,  2.1752722 , -0.18192514],
-        [ 0.69450446, -0.3453008 , -1.4687618 , -0.83728588,  1.86690121, -1.37613417, -0.45294696,  2.2534642 , -0.18192514],
-        [ 0.72563236, -0.3453008 , -1.4687618 , -0.76398188,  1.86690121, -1.37613417, -0.45294696,  2.3316562 , -0.18192514],
-        [ 0.76563236, -0.3053008 , -1.3500778 , -1.24592425,  1.45504207, -1.92796248, -0.33426296,  2.4098482 , -0.06324114],
-        [ 0.80563236, -0.2653008 , -1.2313938 , -1.24592425,  1.45504207, -1.92796248, -0.21557896,  2.4880402 ,  0.05544286],
-        [ 0.84563236, -0.2253008 , -1.22741608, -1.24592425,  1.45504207, -1.92796248, -0.09689496,  2.5662322 ,  0.17412686],
-        [ 0.88563236, -0.1853008 , -1.22741608, -1.24592425,  1.45504207, -1.92796248, -0.04868062,  2.6444242 ,  0.29281086],
-        [ 0.92563236, -0.16862102, -1.22741608, -1.24592425,  1.45504207, -1.92796248, -0.04868062,  2.7226162 ,  0.41149486],
-        [ 0.88362817, -0.12862102, -1.66833447, -1.17262025,  1.57372607, -2.16886715, -0.56370871,  2.8008082 ,  0.53017886],
-        [ 0.88362817, -0.08862102, -1.66833447, -1.09931625,  1.60165799, -2.16886715, -0.56370871,  2.8790002 ,  0.64886286],
-        [ 0.88362817, -0.04862102, -1.66833447, -1.02601225,  1.60165799, -2.16886715, -0.56370871,  2.9571922 ,  0.76754686],
-        [ 0.88362817, -0.00862102, -1.66833447, -0.95270825,  1.60165799, -2.16886715, -0.56370871,  3.0353842 ,  0.88623086],
-        [ 0.88362817,  0.03137898, -1.66833447, -0.87940425,  1.60165799, -2.16886715, -0.56370871,  3.1135762 ,  1.00491486],
-        [ 0.88413797,  0.07137898, -1.63189238, -0.89563487,  1.72034199, -2.22824166, -0.62438836,  3.1346112 ,  0.95150129],
-        [ 0.8817875 ,  0.11137898, -1.62654789, -0.88103191,  1.83902599, -2.30894172, -0.66511573,  3.15319158,  0.91617005]
-    ]
-    
+def test_vis(scenario: int = 21, waypoints: List[List[float]] = ()):
+    scenario = int(scenario)
+    if len(waypoints) == 0:
+        waypoints = [
+            [0.,  0., -0.01779206, -0.76012354,  0.01978261, -
+                2.34205014,  0.02984053,  1.54119353,  0.75344866],
+            [0.04,  0.04,  0.07543812, -0.72490447,  0.07638708, -
+                2.37448407,  0.06908042,  1.54488921,  0.67831372],
+            [0.08,  0.08,  0.1657339, -0.6865332,  0.12951995, -
+                2.40180711,  0.10798703,  1.55301725,  0.60104267],
+            [0.03348037, -0.13874396,  0.2844179, -0.6132292,  0.24820395, -
+                2.33897511,  0.22667103,  1.63120925, -1.23003653],
+            [0.03348037, -0.13874396,  0.4031019, -0.5399252,  0.36688795, -
+                2.27614311,  0.34535503,  1.70940125, -1.23003653],
+            [0.03348037, -0.13874396,  0.51508008, -0.4666212,  0.48557195, -
+                2.24875362,  0.46403903,  1.78759325, -1.23003653],
+            [0.03348037, -0.13874396,  0.51508008, -0.3933172,  0.60425595, -
+                2.24875362,  0.58272303,  1.86578525, -1.23003653],
+            [0.03348037, -0.13874396,  0.51508008, -0.3200132,  0.72293995, -
+                2.24875362,  0.70140703,  1.94397725, -1.23003653],
+            [0.07348037, -0.22830728,  0.63376408, -0.2467092,  0.84162395, -
+                2.18592162,  0.82009103,  2.02216925, -1.11135253],
+            [0.11348037, -0.22830728,  0.74118352, -0.1734052,  0.96030795, -
+                2.12308962,  0.93877503,  2.10036125, -0.99266853],
+            [0.15348037, -0.22830728,  0.74118352, -0.1001012,  1.07899195, -
+                2.06025762,  1.05745903,  2.17855325, -0.87398453],
+            [0.19348037, -0.22830728,  0.74118352, -0.0267972,  1.19767595, -
+                1.99742562,  1.17614303,  2.25674525, -0.75530053],
+            [0.21450446, -0.18830728,  0.18224764, -1.16490337,  1.31635995, -
+                1.93459362,  1.12311681,  2.33493725, -1.06778578],
+            [0.21450446, -0.14830728,  0.18224764, -1.16490337,  1.43504395, -
+                1.87176162,  1.12311681,  2.36596726, -1.06778578],
+            [0.21450446, -0.10830728,  0.18224764, -1.16490337,  1.55372795, -
+                1.80892962,  1.12311681,  2.36596726, -1.06778578],
+            [0.21450446, -0.06830728,  0.18224764, -1.16490337,  1.67241195, -
+                1.74609762,  1.12311681,  2.36596726, -1.06778578],
+            [0.21450446, -0.02830728,  0.18224764, -1.16490337,  1.79109595, -
+                1.68326562,  1.12311681,  2.36596726, -1.06778578],
+            [0.25450446, -0.1576753,  0.30093164, -1.35041388,  1.50455529, -
+                1.62043362,  0.50948168,  2.44415926, -0.94910178],
+            [0.29450446, -0.1576753,  0.41961564, -1.35041388,  1.50455529, -
+                1.55760162,  0.50948168,  2.52235126, -0.83041778],
+            [0.33450446, -0.1576753,  0.53829964, -1.35041388,  1.50455529, -
+                1.49476962,  0.50948168,  2.60054326, -0.71173378],
+            [0.37450446, -0.1576753,  0.65698364, -1.35041388,  1.50455529, -
+                1.43193762,  0.50948168,  2.67873526, -0.59304978],
+            [0.41450446, -0.1576753,  0.77566764, -1.35041388,  1.50455529, -
+                1.36910562,  0.50948168,  2.75692726, -0.47436578],
+            [0.45450446, -0.1176753,  0.46978508, -1.27710988,  1.62323929, -
+                1.30627362,  0.62816568,  2.56588813, -0.35568178],
+            [0.49450446, -0.0776753,  0.46978508, -1.20380588,  1.74192329, -
+                1.26018591,  0.74684968,  2.56588813, -0.23699778],
+            [0.53450446, -0.31055444,  0.58846908, -1.13050188,  1.86060729, -
+                1.19735391, -0.01269374,  1.9406962, -0.27375675],
+            [0.57450446, -0.3453008, -1.4687618, -1.05719788,  1.86690121, -
+                1.37613417, -0.45294696,  2.0188882, -0.18192514],
+            [0.61450446, -0.3453008, -1.4687618, -0.98389388,  1.86690121, -
+                1.37613417, -0.45294696,  2.0970802, -0.18192514],
+            [0.65450446, -0.3453008, -1.4687618, -0.91058988,  1.86690121, -
+                1.37613417, -0.45294696,  2.1752722, -0.18192514],
+            [0.69450446, -0.3453008, -1.4687618, -0.83728588,  1.86690121, -
+                1.37613417, -0.45294696,  2.2534642, -0.18192514],
+            [0.72563236, -0.3453008, -1.4687618, -0.76398188,  1.86690121, -
+                1.37613417, -0.45294696,  2.3316562, -0.18192514],
+            [0.76563236, -0.3053008, -1.3500778, -1.24592425,  1.45504207, -
+                1.92796248, -0.33426296,  2.4098482, -0.06324114],
+            [0.80563236, -0.2653008, -1.2313938, -1.24592425,  1.45504207, -
+                1.92796248, -0.21557896,  2.4880402,  0.05544286],
+            [0.84563236, -0.2253008, -1.22741608, -1.24592425,  1.45504207, -
+                1.92796248, -0.09689496,  2.5662322,  0.17412686],
+            [0.88563236, -0.1853008, -1.22741608, -1.24592425,  1.45504207, -
+                1.92796248, -0.04868062,  2.6444242,  0.29281086],
+            [0.92563236, -0.16862102, -1.22741608, -1.24592425,  1.45504207, -
+                1.92796248, -0.04868062,  2.7226162,  0.41149486],
+            [0.88362817, -0.12862102, -1.66833447, -1.17262025,  1.57372607, -
+                2.16886715, -0.56370871,  2.8008082,  0.53017886],
+            [0.88362817, -0.08862102, -1.66833447, -1.09931625,  1.60165799, -
+                2.16886715, -0.56370871,  2.8790002,  0.64886286],
+            [0.88362817, -0.04862102, -1.66833447, -1.02601225,  1.60165799, -
+                2.16886715, -0.56370871,  2.9571922,  0.76754686],
+            [0.88362817, -0.00862102, -1.66833447, -0.95270825,  1.60165799, -
+                2.16886715, -0.56370871,  3.0353842,  0.88623086],
+            [0.88362817,  0.03137898, -1.66833447, -0.87940425,  1.60165799, -
+                2.16886715, -0.56370871,  3.1135762,  1.00491486],
+            [0.88413797,  0.07137898, -1.63189238, -0.89563487,  1.72034199, -
+                2.22824166, -0.62438836,  3.1346112,  0.95150129],
+            [0.8817875,  0.11137898, -1.62654789, -0.88103191,  1.83902599, -
+                2.30894172, -0.66511573,  3.15319158,  0.91617005]
+        ]
+
     target = np.eye(4)
     target[:3, 3] = [1.0, 1.0, 0.2]
 
-    s = Scenario(21)
+    s = Scenario(scenario_id=scenario)
     visualize_waypoints(s, waypoints, step_time=0)
 
 
 def show_scenarios():
     for i in range(4):
-        s = Scenario(i + 1)
-        show_scenario(s)
+        for k in range(4):
+            s = Scenario(k + 1 + (i + 1) * 10)
+            show_scenario(s)
 
 
 def read_waypoints_from_file(filename):
@@ -307,22 +381,61 @@ def batch_create_videos(directory):
             continue
         filename = os.path.join(directory, file)
         print(f'creating video for {filename}')
-        print('scenario id:', file[len('scenario'):len('scenario')+2])
-        scenario_id = int(file[len('scenario'):len('scenario')+2])
+        id_list = re.findall(r"\d{2,}", file)
+        if len(id_list) == 0:
+            raise Exception(
+                "Could not find scenario ID in form of an integer like \\d{2,}")
+        scenario_id = int(id_list[0])
+        # scenario_id = int(file[len('scenario'):len('scenario')+2])
         scenario = Scenario(scenario_id)
         waypoints = read_waypoints_from_file(filename)
         video_fn = os.path.join(vid_dir, file.replace('.csv', ''))
-        create_video(scenario, waypoints, video_fn, renderer=FourImageRenderer(scenario), fps=2)
+        create_video(scenario, waypoints, video_fn,
+                     renderer=FourImageRenderer(scenario), fps=2)
 
 
 if __name__ == '__main__':
-    if len(sys.argv) < 3:
-        print("usage: ", sys.argv[0], " <scenario> <trajectory.try> <outprefix> ")
+    parser = argparse.ArgumentParser(prog="Visualize trajectories",
+                                     description="Visualize trajectories either by copy pasting from the file or by argument")
+    parser.add_argument('--scenario', help="Scenario to visualize")
+    parser.add_argument(
+        '--traj_file', help="Trajectory file to visualize with above scenario")
+    parser.add_argument('--results', default="results",
+                        help="Directory with the results to render")
+
+    args = parser.parse_args()
+
+    if args.scenario is None or args.traj_file is None:
+        print("Usage: ", sys.argv[0], "<scenario> <trajectory.csv>")
+        print("\nEXAMPLES:\n")
+        print("Render trajectory example? [Y/n]")
+        c = input()
+        if not (len(c) > 0 and c.lower() != "y"):
+            test_vis()
+        print("Show all scenarios one by one? [Y/n]")
+        c = input()
+        if not (len(c) > 0 and c.lower() != "y"):
+            show_scenarios()
+        print("Render videos of trajectories? [Y/n]")
+        c = input()
+        if not (len(c) > 0 and c.lower() != "y"):
+            print(f"RENDERING VIDEOS FROM {args.results}")
+            batch_create_videos(args.results)
         quit()
-    scenario = sys.argv[1]
-    trajFile = sys.argv[2]
-    prefix = sys.argv[3]
-    test_vis(scenario, trajFile)
-    # show_scenarios()
+
+    scenario = args.scenario
+    traj_file = args.traj_file
+    waypoints = []
+    with open(traj_file, 'r') as file:
+        reader = csv.reader(file)
+        for row in reader:
+            # Convert each value in the row to a float and append it to the data list
+            row_array = [float(value) for value in row]
+            if len(row_array) > 0:
+                waypoints.append(row_array)
+            print(waypoints[-1])
+    # print(waypoints)
+    # test_vis(scenario, waypoints)
+    show_scenarios()
 
     # batch_create_videos('../Burs/blind_trajectories/')

--- a/visualization.py
+++ b/visualization.py
@@ -435,7 +435,7 @@ if __name__ == '__main__':
                 waypoints.append(row_array)
             print(waypoints[-1])
     # print(waypoints)
-    # test_vis(scenario, waypoints)
-    show_scenarios()
+    test_vis(scenario, waypoints)
+    # show_scenarios()
 
     # batch_create_videos('../Burs/blind_trajectories/')

--- a/visualization.py
+++ b/visualization.py
@@ -435,6 +435,12 @@ if __name__ == '__main__':
                 waypoints.append(row_array)
             print(waypoints[-1])
     # print(waypoints)
+    """EXAMPLE from jogramop-planners results:
+    python jogramop-framework/visualization.py --scenario 013 --traj_file results/s011-p0-s1.csv
+
+    EXAMPLE on video rendering:
+    python jogramop-framework/visualization.py --results results/
+    """
     test_vis(scenario, waypoints)
     # show_scenarios()
 


### PR DESCRIPTION
I added handling of relative paths so `visualization.py` can be run outside of the `jogramop-framework/` directory:
- I.e. like so `os.path.join(os.path.dirname(__file__), 'robots/franka_panda/panda.urdf')`
  - By default it runs like the equivalent of `os.path.join(os.getcwd(), 'robots/franka_panda/panda.urdf')` where `os.getcwd()` is the location that `python` was run from. It was normally assumed that `os.getcwd() == os.path.dirname(__file__)`.

Also added argument switches at the bottom of `visualization.py` to visualize trajectories, show scenarios or batch create videos.